### PR TITLE
Fix linking error LNK1149 on Windows

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -13,7 +13,7 @@
         'src/eclipse.cc'
       ],
       'dependencies': [
-      	'deps/swisseph/swisseph.gyp:swisseph'
+      	'deps/swisseph/swisseph.gyp:swissephz'
       ],
       "include_dirs": ["<!(node -e \"require('nan')\")"]
     }

--- a/deps/swisseph/swisseph.gyp
+++ b/deps/swisseph/swisseph.gyp
@@ -1,7 +1,7 @@
 {
   'targets': [
     {
-      'target_name': 'swisseph',
+      'target_name': 'swissephz',
       'type': 'static_library',
       'direct_dependent_settings': {
         'include_dirs': ['.']


### PR DESCRIPTION
Making the intermediate target (originally named swisseph) have a different name (now named swissephz) than the final node module target so that the LNK1149 linking error does not happen under windows. This does not affect the final operation of the npm module.